### PR TITLE
Fix KeyCaseSensitive and Stripkey Problem

### DIFF
--- a/lib/mdict-base.js
+++ b/lib/mdict-base.js
@@ -180,12 +180,6 @@ var MDictBase = /*#__PURE__*/function () {
       this.header = _common["default"].parseHeader(headerText); // set header default configuration
 
       this.header.KeyCaseSensitive = this.header.KeyCaseSensitive || 'No';
-      this.compareFn = _common["default"].isTrue(this.header.KeyCaseSensitive) ? _common["default"].normalUpperCaseWordCompare : _common["default"].wordCompare;
-
-      if (this.ext === 'mdd') {
-        this.compareFn = _common["default"].localCompare; // this.compareFn = common.normalUpperCaseWordCompare;
-      }
-
       this.header.StripKey = this.header.StripKey || 'Yes'; // encrypted flag
       // 0x00 - no encryption
       // 0x01 - encrypt record block
@@ -512,7 +506,7 @@ var MDictBase = /*#__PURE__*/function () {
 
   }, {
     key: "_reduceWordKeyBlock",
-    value: function _reduceWordKeyBlock(phrase, _s) {
+    value: function _reduceWordKeyBlock(phrase, _s, compareFn) {
       if (!_s || _s == undefined) {
         // eslint-disable-next-line
         _s = function _s(word) {
@@ -528,9 +522,9 @@ var MDictBase = /*#__PURE__*/function () {
       while (left <= right) {
         mid = left + (right - left >> 1);
 
-        if (this.compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].firstKey)) >= 0 && this.compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) <= 0) {
+        if (compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].firstKey)) >= 0 && compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) <= 0) {
           return mid;
-        } else if (this.compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) >= 0) {
+        } else if (compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) >= 0) {
           left = mid + 1;
         } else {
           right = mid - 1;

--- a/lib/mdict.js
+++ b/lib/mdict.js
@@ -56,50 +56,30 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
   (0, _createClass2["default"])(Mdict, [{
     key: "_stripKey",
     value: function _stripKey() {
-      var keyCaseSensitive = this.searchOptions.keyCaseSensitive || _common["default"].isTrue(this.header.KeyCaseSensitive);
-
       var stripKey = this.searchOptions.stripKey || _common["default"].isTrue(this.header.StripKey);
 
       var regexp = _common["default"].REGEXP_STRIPKEY[this.ext];
-
-      if (keyCaseSensitive) {
-        return stripKey ? function _s(key) {
-          return key.replace(regexp, '$1');
-        } : function _s(key) {
-          return key;
-        };
-      }
-
-      return this.searchOptions.stripKey || _common["default"].isTrue(this.header.StripKey || (this._version >= 2.0 ? '' : 'yes')) ? function _s(key) {
-        return key.toLowerCase().replace(regexp, '$1');
+      return stripKey ? function _s(key) {
+        return key.replace(regexp, "$1");
       } : function _s(key) {
-        return key.toLowerCase();
+        return key;
       };
     }
   }, {
     key: "lookup",
     value: function lookup(word) {
-      var sfunc = this._stripKey();
-
-      var kbid = this._reduceWordKeyBlock(word, sfunc); // not found
+      var record = this._lookupKID(word); // if not found the key block, return undefined
 
 
-      if (kbid < 0) {
+      if (record === undefined) {
         return {
           keyText: word,
           definition: null
         };
       }
 
-      var list = this._decodeKeyBlockByKBID(kbid);
-
-      var i = this._binarySearh(list, word, sfunc); // if not found the key block, return undefined
-
-
-      if (i === undefined) return {
-        keyText: word,
-        definition: null
-      };
+      var i = record.idx;
+      var list = record.list;
 
       var rid = this._reduceRecordBlock(list[i].recordStartOffset);
 
@@ -110,24 +90,56 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       return data;
     }
   }, {
+    key: "_isKeyCaseSensitive",
+    value: function _isKeyCaseSensitive() {
+      return this.searchOptions.keyCaseSensitive || _common["default"].isTrue(this.header.KeyCaseSensitive);
+    }
+  }, {
     key: "_lookupKID",
     value: function _lookupKID(word) {
-      var sfunc = this._stripKey();
+      var _this2 = this;
 
-      var kbid = this._reduceWordKeyBlock(word, sfunc);
+      var lookupInternal = function lookupInternal(compareFn) {
+        var sfunc = _this2._stripKey();
 
-      var list = this._decodeKeyBlockByKBID(kbid);
+        var kbid = _this2._reduceWordKeyBlock(word, sfunc, compareFn); // not found
 
-      var i = this._binarySearh(list, word, sfunc);
 
-      return {
-        idx: i,
-        list: list
+        if (kbid < 0) {
+          return undefined;
+        }
+
+        var list = _this2._decodeKeyBlockByKBID(kbid);
+
+        var i = _this2._binarySearh(list, word, sfunc, compareFn);
+
+        if (i === undefined) {
+          return undefined;
+        }
+
+        return {
+          idx: i,
+          list: list
+        };
       };
+
+      var record;
+
+      if (this._isKeyCaseSensitive()) {
+        record = lookupInternal(_common["default"].normalUpperCaseWordCompare);
+      } else {
+        record = lookupInternal(_common["default"].normalUpperCaseWordCompare);
+
+        if (record === undefined) {
+          record = lookupInternal(_common["default"].wordCompare);
+        }
+      }
+
+      return record;
     }
   }, {
     key: "_binarySearh",
-    value: function _binarySearh(list, word, _s) {
+    value: function _binarySearh(list, word, _s, compareFn) {
       if (!_s || _s == undefined) {
         // eslint-disable-next-line
         _s = this._stripKey();
@@ -144,7 +156,7 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
         // however, if we change the word to lowercase, the binary search algorithm will be confused
         // so, we use the enhanced compare function `common.wordCompare`
 
-        var compareResult = this.compareFn(_s(word), _s(list[mid].keyText)); // console.log(`@#@# wordCompare ${_s(word)} ${_s(list[mid].keyText)} ${compareResult} l: ${left} r: ${right} mid: ${mid} ${list[mid].keyText}`)
+        var compareResult = compareFn(_s(word), _s(list[mid].keyText)); // console.log(`@#@# wordCompare ${_s(word)} ${_s(list[mid].keyText)} ${compareResult} l: ${left} r: ${right} mid: ${mid} ${list[mid].keyText}`)
 
         if (compareResult > 0) {
           left = mid + 1;
@@ -157,6 +169,42 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
 
       return undefined;
     }
+  }, {
+    key: "_findList",
+    value: function _findList(word) {
+      var _this3 = this;
+
+      var findListInternal = function findListInternal(compareFn) {
+        var sfunc = _this3._stripKey();
+
+        var kbid = _this3._reduceWordKeyBlock(word, sfunc, compareFn); // not found
+
+
+        if (kbid < 0) {
+          return undefined;
+        }
+
+        return {
+          sfunc: sfunc,
+          kbid: kbid,
+          list: _this3._decodeKeyBlockByKBID(kbid)
+        };
+      };
+
+      var list;
+
+      if (this._isKeyCaseSensitive()) {
+        list = findListInternal(_common["default"].normalUpperCaseWordCompare);
+      } else {
+        list = findListInternal(_common["default"].normalUpperCaseWordCompare);
+
+        if (list === undefined) {
+          list = findListInternal(_common["default"].wordCompare);
+        }
+      }
+
+      return list;
+    }
     /**
      * get word prefix words
      * @param {string} phrase the word which needs to find prefix
@@ -165,11 +213,7 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
   }, {
     key: "prefix",
     value: function prefix(phrase) {
-      var sfunc = this._stripKey();
-
-      var kbid = this._reduceWordKeyBlock(phrase, sfunc);
-
-      var list = this._decodeKeyBlockByKBID(kbid);
+      var list = this._findList(phrase).list;
 
       var trie = _doublearray["default"].builder().build(list.map(function (keyword) {
         return {
@@ -193,12 +237,11 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
   }, {
     key: "associate",
     value: function associate(phrase) {
-      var sfunc = this._stripKey();
+      var record = this._findList(phrase);
 
-      var kbid = this._reduceWordKeyBlock(phrase, sfunc);
-
-      var list = this._decodeKeyBlockByKBID(kbid);
-
+      var sfunc = record.sfunc;
+      var kbid = record.kbid;
+      var list = record.list;
       var matched = list.filter(function (item) {
         return sfunc(item.keyText).startsWith(sfunc(phrase));
       });
@@ -245,7 +288,7 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
   }, {
     key: "fuzzy_search",
     value: function fuzzy_search(word, fuzzy_size, ed_gap) {
-      var _this2 = this;
+      var _this4 = this;
 
       var fwords = [];
       var fuzzy_words = [];
@@ -258,11 +301,11 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       }));
       fuzzy_size = fuzzy_size - fwords.length < 0 ? 0 : fuzzy_size - fwords.length;
       fwords.map(function (fw) {
-        var _this2$_lookupKID = _this2._lookupKID(fw.key),
-            idx = _this2$_lookupKID.idx,
-            list = _this2$_lookupKID.list;
+        var _this4$_lookupKID = _this4._lookupKID(fw.key),
+            idx = _this4$_lookupKID.idx,
+            list = _this4$_lookupKID.list;
 
-        return _this2._find_nabor(idx, Math.ceil(fuzzy_size / fwords.length), list).filter(function (item) {
+        return _this4._find_nabor(idx, Math.ceil(fuzzy_size / fwords.length), list).filter(function (item) {
           return _common["default"].levenshtein_distance(item.keyText, word) <= ed_gap;
         }).map(function (kitem) {
           return fuzzy_words.push({

--- a/lib/mdict.js
+++ b/lib/mdict.js
@@ -62,12 +62,6 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
 
       var regexp = _common["default"].REGEXP_STRIPKEY[this.ext];
 
-      if (this.ext === 'mdd') {
-        return function _s(key) {
-          return key;
-        };
-      }
-
       if (keyCaseSensitive) {
         return stripKey ? function _s(key) {
           return key.replace(regexp, '$1');

--- a/lib/mdict.js
+++ b/lib/mdict.js
@@ -48,8 +48,8 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
     _this.searchOptions = {};
     searchOptions = searchOptions || {};
     _this.searchOptions.passcode = searchOptions.passcode || undefined;
-    _this.searchOptions.keyCaseSensitive = searchOptions.keyCaseSensitive == undefined ? true : searchOptions.keyCaseSensitive;
-    _this.searchOptions.stripKey = searchOptions.stripKey == undefined ? true : searchOptions.stripKey;
+    _this.searchOptions.keyCaseSensitive = searchOptions.keyCaseSensitive;
+    _this.searchOptions.stripKey = searchOptions.stripKey;
     return _this;
   }
 
@@ -98,9 +98,15 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       }
 
       var list = this._decodeKeyBlockByKBID(kbid);
-      var i = this._binarySearh(list, word, sfunc);
-      // if not found the key block, return undefined
-      if (i === undefined) return { keyText: word, definition: null };
+
+      var i = this._binarySearh(list, word, sfunc); // if not found the key block, return undefined
+
+
+      if (i === undefined) return {
+        keyText: word,
+        definition: null
+      };
+
       var rid = this._reduceRecordBlock(list[i].recordStartOffset);
 
       var nextStart = i + 1 >= list.length ? this._recordBlockStartOffset + this.recordBlockInfoList[this.recordBlockInfoList.length - 1].decompAccumulator + this.recordBlockInfoList[this.recordBlockInfoList.length - 1].decompSize : list[i + 1].recordStartOffset;
@@ -136,9 +142,9 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       var left = 0;
       var right = list.length;
       var mid = 0;
+
       while (left <= right) {
-        mid = left + (right - left >> 1);
-        // if case sensitive, the uppercase word is smaller than lowercase word
+        mid = left + (right - left >> 1); // if case sensitive, the uppercase word is smaller than lowercase word
         // for example: `Holanda` is smaller than `abacaxi`
         // so when comparing with the words, we should use the dictionary order,
         // however, if we change the word to lowercase, the binary search algorithm will be confused
@@ -154,6 +160,7 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
           right = mid - 1;
         }
       }
+
       return undefined;
     }
     /**
@@ -213,7 +220,7 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
 
 
       matched.map(function (item) {
-        item.roffset = item.recordStartOffset;
+        item.rofset = item.recordStartOffset;
       });
       return matched;
     }

--- a/lib/mdict.js
+++ b/lib/mdict.js
@@ -98,15 +98,9 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       }
 
       var list = this._decodeKeyBlockByKBID(kbid);
-
-      var i = this._binarySearh(list, word, sfunc); // if not found the key block, return undefined
-
-
-      if (!list[i]) return {
-        keyText: word,
-        definition: null
-      };
-
+      var i = this._binarySearh(list, word, sfunc);
+      // if not found the key block, return undefined
+      if (i === undefined) return { keyText: word, definition: null };
       var rid = this._reduceRecordBlock(list[i].recordStartOffset);
 
       var nextStart = i + 1 >= list.length ? this._recordBlockStartOffset + this.recordBlockInfoList[this.recordBlockInfoList.length - 1].decompAccumulator + this.recordBlockInfoList[this.recordBlockInfoList.length - 1].decompSize : list[i + 1].recordStartOffset;
@@ -142,9 +136,9 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       var left = 0;
       var right = list.length;
       var mid = 0;
-
-      while (left < right) {
-        mid = left + (right - left >> 1); // if case sensitive, the uppercase word is smaller than lowercase word
+      while (left <= right) {
+        mid = left + (right - left >> 1);
+        // if case sensitive, the uppercase word is smaller than lowercase word
         // for example: `Holanda` is smaller than `abacaxi`
         // so when comparing with the words, we should use the dictionary order,
         // however, if we change the word to lowercase, the binary search algorithm will be confused
@@ -160,8 +154,7 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
           right = mid - 1;
         }
       }
-
-      return left;
+      return undefined;
     }
     /**
      * get word prefix words
@@ -220,7 +213,7 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
 
 
       matched.map(function (item) {
-        item.rofset = item.recordStartOffset;
+        item.roffset = item.recordStartOffset;
       });
       return matched;
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/mdict.js",
   "types": "typings/mdict.d.ts",
   "scripts": {
-    "debug": "npm run build && mocha --require @babel/register test/debug.test.js",
+    "debug": "npm run build && mocha --require @babel/register test/debug.spec.js",
     "test": "npm run build && mocha --require @babel/register test/*.spec.js",
     "coverage": "npm run build && nyc mocha --require @babel/register",
     "jest": "npm run build && jest test/*.spec.js",

--- a/src/mdict-base.js
+++ b/src/mdict-base.js
@@ -168,13 +168,7 @@ class MDictBase {
 
     // set header default configuration
     this.header.KeyCaseSensitive = this.header.KeyCaseSensitive || 'No';
-    this.compareFn = common.isTrue(this.header.KeyCaseSensitive)
-      ? common.normalUpperCaseWordCompare
-      : common.wordCompare;
-    if (this.ext === 'mdd') {
-      this.compareFn = common.localCompare;
-      // this.compareFn = common.normalUpperCaseWordCompare;
-    }
+
     this.header.StripKey = this.header.StripKey || 'Yes';
 
     // encrypted flag
@@ -550,7 +544,7 @@ class MDictBase {
    * @param {string} phrase searching phrase
    * @param {function} stripfunc strip key string to compare
    */
-  _reduceWordKeyBlock(phrase, _s) {
+  _reduceWordKeyBlock(phrase, _s, compareFn) {
     if (!_s || _s == undefined) {
       // eslint-disable-next-line
       _s = (word) => {
@@ -566,13 +560,13 @@ class MDictBase {
     while (left <= right) {
       mid = left + ((right - left) >> 1);
       if (
-        this.compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].firstKey)) >=
+        compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].firstKey)) >=
           0 &&
-        this.compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) <= 0
+        compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) <= 0
       ) {
         return mid;
       } else if (
-        this.compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) >= 0
+        compareFn(_s(phrase), _s(this.keyBlockInfoList[mid].lastKey)) >= 0
       ) {
         left = mid + 1;
       } else {

--- a/src/mdict.js
+++ b/src/mdict.js
@@ -15,12 +15,8 @@ class Mdict extends MdictBase {
     this.searchOptions = {};
     searchOptions = searchOptions || {};
     this.searchOptions.passcode = searchOptions.passcode || undefined;
-    this.searchOptions.keyCaseSensitive =
-      searchOptions.keyCaseSensitive == undefined
-        ? true
-        : searchOptions.keyCaseSensitive;
-    this.searchOptions.stripKey =
-      searchOptions.stripKey == undefined ? true : searchOptions.stripKey;
+    this.searchOptions.keyCaseSensitive = searchOptions.keyCaseSensitive;
+    this.searchOptions.stripKey = searchOptions.stripKey;
   }
 
   _stripKey() {

--- a/src/mdict.js
+++ b/src/mdict.js
@@ -67,7 +67,7 @@ class Mdict extends MdictBase {
     const list = this._decodeKeyBlockByKBID(kbid);
     const i = this._binarySearh(list, word, sfunc);
     // if not found the key block, return undefined
-    if (!list[i]) return { keyText: word, definition: null };
+    if (i === undefined) return { keyText: word, definition: null };
     const rid = this._reduceRecordBlock(list[i].recordStartOffset);
     const nextStart =
       i + 1 >= list.length
@@ -102,7 +102,7 @@ class Mdict extends MdictBase {
     let left = 0;
     let right = list.length;
     let mid = 0;
-    while (left < right) {
+    while (left <= right) {
       mid = left + ((right - left) >> 1);
       // if case sensitive, the uppercase word is smaller than lowercase word
       // for example: `Holanda` is smaller than `abacaxi`
@@ -119,7 +119,7 @@ class Mdict extends MdictBase {
         right = mid - 1;
       }
     }
-    return left;
+    return undefined;
   }
 
   /**

--- a/src/mdict.js
+++ b/src/mdict.js
@@ -27,12 +27,6 @@ class Mdict extends MdictBase {
       this.searchOptions.stripKey || common.isTrue(this.header.StripKey);
     const regexp = common.REGEXP_STRIPKEY[this.ext];
 
-    if (this.ext === 'mdd') {
-      return function _s(key) {
-        return key;
-      };
-    }
-
     if (keyCaseSensitive) {
       return stripKey
         ? function _s(key) {


### PR DESCRIPTION
1. 调用者可以强行设置 searchOptions，在不强行设置searchOptions的情况下，遵重词典设置
2. 在大小写不敏感情况下，如果存在精确匹配，则返回精确匹配的条目

通过了所有test测试，debug也不报错，example还没有实验。

我在使用该库过程中，之前无法匹配大小写不一致的css、js等，该 PR 可以解决我遇到的问题。

参见 #41 的讨论。

其它实现相关：

1. 将 `compareFn` this 移除，作为 _reduceWordKeyBlock 和 _binarySearh 的入参。因为 KeyCaseSensitive 为 No 时，先用大小写敏感的 `compareFn`，查不到再用大小写不敏感的 `compareFn`。
2. `_stripKey` 根据 Stripkey 提供 `_s` 函数，`compareFn` 根据 KeyCaseSensitive 设置，两者互相独立，因此删去 `_stripKey` 中的 KeyCaseSensitive 相关的部分。
3. 修改过程中，为复用共同逻辑，进行了轻微重构。