### PR TITLE
fix(package.json): fix "cannot find module" of @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-stage-0": "^7.8.3",
     "@babel/register": "^7.14.5",
+    "@babel/runtime": "^7.14.6",
     "@everymundo/linenumber": "^1.0.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,6 +968,13 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.14.6"
   resolved "https://r.cnpmjs.org/@babel/runtime/download/@babel/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"


### PR DESCRIPTION
解决这个问题：https://github.com/terasum/js-mdict/commit/9cdc7e5dc77db90e3c7c7d009f7c667269dbefc5#r52574247

我之前全局装了 `@babel/runtime` 在引用该库也会报上述错误。

就直接把 `@babel/runtime` 添加到 `devDependencies` 就解决了。