### PR TITLE
fix(common.js, mdict.js): fix compare function bug by refactor

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -256,62 +256,39 @@ function appendBuffer(buffer1, buffer2) {
   tmp.set(new Uint8Array(buffer1), 0);
   tmp.set(new Uint8Array(buffer2), buffer1.byteLength);
   return tmp.buffer;
-}
+} // by ASCII
 
-function wordCompare(word1, word2) {
+
+function plainCompare(word1, word2) {
+  return word1 === word2 ? 0 : word1 > word2 ? 1 : -1;
+} // Case-sensitive match comparison but in case-insensitive mdict key order (aAbB...yYzZ)
+
+
+function caseSensitiveMatchCompare(word1, word2) {
   if (!word1 || !word2) {
-    throw new Error("invalid word comparation ".concat(word1, " and ").concat(word2));
-  } // if the two words are indentical, return 0 directly
-
-
-  if (word1 === word2) {
-    return 0;
+    throw new Error("invalid word comparison ".concat(word1, " and ").concat(word2));
   }
 
-  var len = word1.length > word2.length ? word2.length : word1.length;
-
-  for (var i = 0; i < len; i++) {
-    var w1 = word1[i];
-    var w2 = word2[i];
-
-    if (w1 == w2) {
-      continue; // case1: w1: `H` w2: `h` or `h` and `H`continue
-    } else if (w1.toLowerCase() == w2.toLowerCase()) {
-      continue; // case3: w1: `H` w2: `k`, h < k return -1
-    } else if (w1.toLowerCase() < w2.toLowerCase()) {
-      return -1; // case4: w1: `H` w2: `a`, h > a return 1
-    } else if (w1.toLowerCase() > w2.toLowerCase()) {
-      return 1;
-    }
-  } // case5: `Hello` and `Hellocat`
+  var compare = plainCompare(word1.toLocaleLowerCase(), word2.toLocaleLowerCase());
+  return compare === 0 ? -plainCompare(word1, word2) : compare;
+} // Case-insensitive match comparison in case-insensitive mdict key order (aAbB...yYzZ)
 
 
-  return word1.length < word2.length ? -1 : 1;
-} // if this.header.KeyCaseSensitive = YES,
-// Uppercase character is placed in the start position of the directionary
-// so if `this.header.KeyCaseSensitive = YES` use normalUpperCaseWordCompare, else use wordCompare
-
-
-function normalUpperCaseWordCompare(word1, word2) {
-  if (word1 === word2) {
-    return 0;
-  } else if (word1 > word2) {
-    return 1;
-  } else {
-    return -1;
+function caseInsensitiveMatchCompare(word1, word2) {
+  if (!word1 || !word2) {
+    throw new Error("invalid word comparison ".concat(word1, " and ").concat(word2));
   }
-} // this compare function is for mdd file
+
+  return plainCompare(word1.toLocaleLowerCase(), word2.toLocaleLowerCase());
+} // Case-sensitive match comparison in case-sensitive mdict key order (AB...YZab...cd)
 
 
-function localCompare(word1, word2) {
-  // return word1.localeCompare(word2);
-  if (word1.localeCompare(word2) === 0) {
-    return 0;
-  } else if (word1 > word2) {
-    return 1;
-  } else {
-    return -1;
+function caseSensitiveCompare(word1, word2) {
+  if (!word1 || !word2) {
+    throw new Error("invalid word comparison ".concat(word1, " and ").concat(word2));
   }
+
+  return plainCompare(word1, word2);
 }
 /**
  * Test if a value of dictionary attribute is true or not.
@@ -336,9 +313,9 @@ var _default = {
   readNumber: readNumber,
   mdxDecrypt: mdxDecrypt,
   appendBuffer: appendBuffer,
-  wordCompare: wordCompare,
-  normalUpperCaseWordCompare: normalUpperCaseWordCompare,
-  localCompare: localCompare,
+  caseSensitiveMatchCompare: caseSensitiveMatchCompare,
+  caseInsensitiveMatchCompare: caseInsensitiveMatchCompare,
+  caseSensitiveCompare: caseSensitiveCompare,
   isTrue: isTrue,
   NUMFMT_UINT8: NUMFMT_UINT8,
   NUMFMT_UINT16: NUMFMT_UINT16,

--- a/lib/mdict.js
+++ b/lib/mdict.js
@@ -126,12 +126,12 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       var record;
 
       if (this._isKeyCaseSensitive()) {
-        record = lookupInternal(_common["default"].normalUpperCaseWordCompare);
+        record = lookupInternal(_common["default"].caseSensitiveCompare);
       } else {
-        record = lookupInternal(_common["default"].normalUpperCaseWordCompare);
+        record = lookupInternal(_common["default"].caseSensitiveMatchCompare);
 
         if (record === undefined) {
-          record = lookupInternal(_common["default"].wordCompare);
+          record = lookupInternal(_common["default"].caseInsensitiveMatchCompare);
         }
       }
 
@@ -150,13 +150,8 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       var mid = 0;
 
       while (left <= right) {
-        mid = left + (right - left >> 1); // if case sensitive, the uppercase word is smaller than lowercase word
-        // for example: `Holanda` is smaller than `abacaxi`
-        // so when comparing with the words, we should use the dictionary order,
-        // however, if we change the word to lowercase, the binary search algorithm will be confused
-        // so, we use the enhanced compare function `common.wordCompare`
-
-        var compareResult = compareFn(_s(word), _s(list[mid].keyText)); // console.log(`@#@# wordCompare ${_s(word)} ${_s(list[mid].keyText)} ${compareResult} l: ${left} r: ${right} mid: ${mid} ${list[mid].keyText}`)
+        mid = left + (right - left >> 1);
+        var compareResult = compareFn(_s(word), _s(list[mid].keyText));
 
         if (compareResult > 0) {
           left = mid + 1;
@@ -194,13 +189,9 @@ var Mdict = /*#__PURE__*/function (_MdictBase) {
       var list;
 
       if (this._isKeyCaseSensitive()) {
-        list = findListInternal(_common["default"].normalUpperCaseWordCompare);
+        list = findListInternal(_common["default"].caseSensitiveCompare);
       } else {
-        list = findListInternal(_common["default"].normalUpperCaseWordCompare);
-
-        if (list === undefined) {
-          list = findListInternal(_common["default"].wordCompare);
-        }
+        list = findListInternal(_common["default"].caseSensitiveMatchCompare);
       }
 
       return list;

--- a/src/common.js
+++ b/src/common.js
@@ -227,58 +227,34 @@ function appendBuffer(buffer1, buffer2) {
   return tmp.buffer;
 }
 
-function wordCompare(word1, word2) {
+// by ASCII
+function plainCompare(word1, word2) {
+  return word1 === word2 ? 0 : (word1 > word2 ? 1 : -1);
+}
+
+// Case-sensitive match comparison but in case-insensitive mdict key order (aAbB...yYzZ)
+function caseSensitiveMatchCompare(word1, word2) {
   if (!word1 || !word2) {
-    throw new Error(`invalid word comparation ${word1} and ${word2}`);
+    throw new Error(`invalid word comparison ${word1} and ${word2}`);
   }
-  // if the two words are indentical, return 0 directly
-  if (word1 === word2) {
-    return 0;
-  }
-  let len = word1.length > word2.length ? word2.length : word1.length;
-  for (let i = 0; i < len; i++) {
-    let w1 = word1[i];
-    let w2 = word2[i];
-    if (w1 == w2) {
-      continue;
-      // case1: w1: `H` w2: `h` or `h` and `H`continue
-    } else if (w1.toLowerCase() == w2.toLowerCase()) {
-      continue;
-      // case3: w1: `H` w2: `k`, h < k return -1
-    } else if (w1.toLowerCase() < w2.toLowerCase()) {
-      return -1;
-      // case4: w1: `H` w2: `a`, h > a return 1
-    } else if (w1.toLowerCase() > w2.toLowerCase()) {
-      return 1;
-    }
-  }
-  // case5: `Hello` and `Hellocat`
-  return word1.length < word2.length ? -1 : 1;
+  const compare = plainCompare(word1.toLocaleLowerCase(), word2.toLocaleLowerCase());
+  return compare === 0 ? -plainCompare(word1, word2) : compare;
 }
 
-// if this.header.KeyCaseSensitive = YES,
-// Uppercase character is placed in the start position of the directionary
-// so if `this.header.KeyCaseSensitive = YES` use normalUpperCaseWordCompare, else use wordCompare
-function normalUpperCaseWordCompare(word1, word2) {
-  if (word1 === word2) {
-    return 0;
-  } else if (word1 > word2) {
-    return 1;
-  } else {
-    return -1;
+// Case-insensitive match comparison in case-insensitive mdict key order (aAbB...yYzZ)
+function caseInsensitiveMatchCompare(word1, word2) {
+  if (!word1 || !word2) {
+    throw new Error(`invalid word comparison ${word1} and ${word2}`);
   }
+  return plainCompare(word1.toLocaleLowerCase(), word2.toLocaleLowerCase());
 }
 
-// this compare function is for mdd file
-function localCompare(word1, word2) {
-  // return word1.localeCompare(word2);
-  if (word1.localeCompare(word2) === 0) {
-    return 0;
-  } else if (word1 > word2) {
-    return 1;
-  } else {
-    return -1;
+// Case-sensitive match comparison in case-sensitive mdict key order (AB...YZab...cd)
+function caseSensitiveCompare(word1, word2) {
+  if (!word1 || !word2) {
+    throw new Error(`invalid word comparison ${word1} and ${word2}`);
   }
+  return plainCompare(word1, word2);
 }
 
 /**
@@ -302,9 +278,9 @@ export default {
   readNumber,
   mdxDecrypt,
   appendBuffer,
-  wordCompare,
-  normalUpperCaseWordCompare,
-  localCompare,
+  caseSensitiveMatchCompare,
+  caseInsensitiveMatchCompare,
+  caseSensitiveCompare,
   isTrue,
   NUMFMT_UINT8,
   NUMFMT_UINT16,

--- a/src/mdict.js
+++ b/src/mdict.js
@@ -88,11 +88,11 @@ class Mdict extends MdictBase {
 
     let record;
     if (this._isKeyCaseSensitive()) {
-      record = lookupInternal(common.normalUpperCaseWordCompare);
+      record = lookupInternal(common.caseSensitiveCompare);
     } else {
-      record = lookupInternal(common.normalUpperCaseWordCompare);
+      record = lookupInternal(common.caseSensitiveMatchCompare);
       if (record === undefined) {
-        record = lookupInternal(common.wordCompare);
+        record = lookupInternal(common.caseInsensitiveMatchCompare);
       }
     }
     return record;
@@ -108,13 +108,7 @@ class Mdict extends MdictBase {
     let mid = 0;
     while (left <= right) {
       mid = left + ((right - left) >> 1);
-      // if case sensitive, the uppercase word is smaller than lowercase word
-      // for example: `Holanda` is smaller than `abacaxi`
-      // so when comparing with the words, we should use the dictionary order,
-      // however, if we change the word to lowercase, the binary search algorithm will be confused
-      // so, we use the enhanced compare function `common.wordCompare`
       const compareResult = compareFn(_s(word), _s(list[mid].keyText));
-      // console.log(`@#@# wordCompare ${_s(word)} ${_s(list[mid].keyText)} ${compareResult} l: ${left} r: ${right} mid: ${mid} ${list[mid].keyText}`)
       if (compareResult > 0) {
         left = mid + 1;
       } else if (compareResult == 0) {
@@ -139,12 +133,9 @@ class Mdict extends MdictBase {
 
     let list;
     if (this._isKeyCaseSensitive()) {
-      list = findListInternal(common.normalUpperCaseWordCompare);
+      list = findListInternal(common.caseSensitiveCompare);
     } else {
-      list = findListInternal(common.normalUpperCaseWordCompare);
-      if (list === undefined) {
-        list = findListInternal(common.wordCompare);
-      }
+      list = findListInternal(common.caseSensitiveMatchCompare);
     }
     return list;
   }


### PR DESCRIPTION
- The original `wordCompare` has a bug that it will return 1 when `word1` and `word2` are case-insensitively equal because of the last return line.
- Implement case sensitive/insensitive comparison by `localeCompare` and `toLocaleLowerCase`
- Rename the compare function with semantic description.
- Remove outdated comments.

Related Question:

https://github.com/terasum/js-mdict/commit/9cdc7e5dc77db90e3c7c7d009f7c667269dbefc5#r52673282
https://github.com/terasum/js-mdict/commit/8e40a316be0ca4ffbc46e80cdefc34709bef9eb8#r52674599